### PR TITLE
Stub GameEngine methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Binaries directory
+bin/
+
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+CPPC = g++
+FLAGS = -g -pedantic -Wall -Wextra -Werror -std=c++11
+SDLFLAGS = `pkg-config --cflags --libs sdl2`
+SRC = src
+BIN = bin
+OBJ = obj
+ALL = $(BIN)/CLIGame
+
+all: $(OBJ) $(BIN) $(ALL)
+
+$(BIN):
+	mkdir -p $(BIN)
+
+$(OBJ):
+	mkdir -p $(OBJ)
+
+$(OBJ)/GameEngine.o: $(SRC)/GameEngine.cpp $(SRC)/GameEngine.h
+	$(CPPC) $(FLAGS) -c -o $(OBJ)/GameEngine.o $(SRC)/GameEngine.cpp
+
+$(OBJ)/CLIGame.o: $(SRC)/CLIGame.cpp $(SRC)/GameEngine.h
+	$(CPPC) $(FLAGS) -c -o $(OBJ)/CLIGame.o $(SRC)/CLIGame.cpp
+
+$(BIN)/CLIGame: $(OBJ)/GameEngine.o $(OBJ)/CLIGame.o
+	$(CPPC) $(FLAGS) -o $(BIN)/CLIGame $(OBJ)/GameEngine.o $(OBJ)/CLIGame.o
+
+clean:
+	rm -f $(ALL)
+	rm -rf $(BIN)/*.dSYM $(OBJ)/*.o

--- a/src/CLIGame.cpp
+++ b/src/CLIGame.cpp
@@ -1,21 +1,16 @@
 #include <iostream>
-#include <memory>
 #include "GameEngine.h"
 
 int main() {
     GameEngine *game = new GameEngine();
-    std::unique_ptr<struct GameState> gameState;
-    std::unique_ptr<struct InputState> inp = std::unique_ptr<struct InputState>
-        (new struct InputState());
-    inp->mainThruster = true;
-    inp->rotLeftThruster = false;
-    inp->rotRightThruster = false;
+    struct GameState gameState;
+    struct InputState inp = {true, false, false};
     gameState = game->step(inp);
-    std::cout << gameState->shipYPos << "\n";
+    std::cout << gameState.shipYPos << "\n";
 
-    inp->mainThruster = false;
+    inp.mainThruster = false;
     gameState = game->step(inp);
-    std::cout << gameState->shipYPos << "\n";
+    std::cout << gameState.shipYPos << "\n";
 
     delete game;
 }

--- a/src/CLIGame.cpp
+++ b/src/CLIGame.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <memory>
+#include "GameEngine.h"
+
+int main() {
+    GameEngine *game = new GameEngine();
+    std::unique_ptr<struct GameState> gameState;
+    std::unique_ptr<struct InputState> inp = std::unique_ptr<struct InputState>
+        (new struct InputState());
+    inp->mainThruster = true;
+    inp->rotLeftThruster = false;
+    inp->rotRightThruster = false;
+    gameState = game->step(inp);
+    std::cout << gameState->shipYPos << "\n";
+
+    inp->mainThruster = false;
+    gameState = game->step(inp);
+    std::cout << gameState->shipYPos << "\n";
+
+    delete game;
+}

--- a/src/GameEngine.cpp
+++ b/src/GameEngine.cpp
@@ -1,0 +1,26 @@
+#include "GameEngine.h"
+#include <memory>
+#include <iostream>
+
+
+// Constructor
+GameEngine::GameEngine() {
+    this->fuel = 100;
+
+    this->shipYPos = 800;
+    this->shipXPos = -100;
+    this->shipRotation = 0;
+
+    this->shipYVel = 0;
+    this->shipXVel = 0;
+    this-> shipAngVel = 0;
+
+    this->gameFinished = false;
+}
+
+// Step
+std::unique_ptr<struct GameState> GameEngine::step(
+                std::unique_ptr<struct InputState> const &input) {
+    std::cout << "main: " << input->mainThruster << "\n";
+    return std::unique_ptr<struct GameState>(new struct GameState());
+}

--- a/src/GameEngine.cpp
+++ b/src/GameEngine.cpp
@@ -1,7 +1,5 @@
 #include "GameEngine.h"
-#include <memory>
 #include <iostream>
-
 
 // Constructor
 GameEngine::GameEngine() {
@@ -19,8 +17,8 @@ GameEngine::GameEngine() {
 }
 
 // Step
-std::unique_ptr<struct GameState> GameEngine::step(
-                std::unique_ptr<struct InputState> const &input) {
-    std::cout << "main: " << input->mainThruster << "\n";
-    return std::unique_ptr<struct GameState>(new struct GameState());
+struct GameState GameEngine::step(struct InputState input) {
+    std::cout << "main: " << input.mainThruster << "\n";
+    GameState gameState = {};
+    return gameState;
 }

--- a/src/GameEngine.h
+++ b/src/GameEngine.h
@@ -1,0 +1,48 @@
+#ifndef GAMEENGINE_H
+#define GAMEENGINE_H
+
+#include <memory>
+
+struct GameState {
+    double fuel;
+
+    double shipYPos;  // relative to landing pad; generally positive
+    double shipXPos;  // relative to landing pad; positive or negative
+    double shipYVelocity;  // negative means approaching the pad
+    double shipXvelocity;
+    double shipRotation; /* in DEGREES, where 0 is vertical, 90 is
+                            horizontal with nose pointing right, -90 is
+                            horizontal with nose pointing left, and +180
+                            and -180 are nose pointing down */
+    double shipAngularVelocity;
+
+    bool gameOver;
+    double score;  // round to an int and floor at 0 for GUI.
+};
+
+struct InputState {
+    bool mainThruster;  // up arrow
+    bool rotLeftThruster;  // the thruster on the right that rotates ship left
+    bool rotRightThruster;
+};
+
+class GameEngine {
+    public:
+        GameEngine();  // constructor
+        std::unique_ptr<struct GameState> step(
+                std::unique_ptr<struct InputState> const &input);
+    private:
+        double fuel;
+
+        double shipYPos;
+        double shipXPos;
+        double shipRotation;
+
+        double shipYVel;
+        double shipXVel;
+        double shipAngVel;
+
+        bool gameFinished;
+};
+
+#endif

--- a/src/GameEngine.h
+++ b/src/GameEngine.h
@@ -1,8 +1,6 @@
 #ifndef GAMEENGINE_H
 #define GAMEENGINE_H
 
-#include <memory>
-
 struct GameState {
     double fuel;
 
@@ -29,8 +27,7 @@ struct InputState {
 class GameEngine {
     public:
         GameEngine();  // constructor
-        std::unique_ptr<struct GameState> step(
-                std::unique_ptr<struct InputState> const &input);
+        struct GameState step(struct InputState input);
     private:
         double fuel;
 


### PR DESCRIPTION
I've stubbed GameEngine methods. The GameEngine class will have two methods: a constructor and a step.

In GameEngine.h I define input and output values:

1. GameState (output)
    - float fuel
    - float shipYPos
    - float shipXPos
    - float shipYVelocity
    - float shipXVelocity
    - float shipRotation
    - float shipAngularVelocity
    - boolean gameOver
    - int score

2. InputState (input)
    - boolean mainThruster
    - boolean rotLeftThruster
    - boolean rotRightThruster

3. class GameEngine 
    - constructor
    - GameState step(InputState)
    - int score()

4. int score()
    returns the score output of the game (int)

I *believe* I have covered all of the necessary inputs and outputs. If there's something you think you need, let me know.

I'm (think I'm) using C++ paradigms correctly — things like `std::cout` (to replace `puts` and `printf`) and `new` and `delete` (to replace `malloc` and `free`).