### PR TITLE
Add support for input logging/reading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,14 @@ $(OBJ):
 $(OBJ)/GameEngine.o: $(SRC)/GameEngine.cpp $(SRC)/GameEngine.h $(SRC)/const.h
 	$(CPPC) $(FLAGS) -c -o $(OBJ)/GameEngine.o $(SRC)/GameEngine.cpp
 
-$(OBJ)/GUIGame.o: $(SRC)/GUIGame.cpp $(SRC)/GameEngine.h
+$(OBJ)/GUIGame.o: $(SRC)/GUIGame.cpp $(SRC)/GameEngine.h $(SRC)/BitBuffer.h
 	$(CPPC) $(FLAGS) -c -o $(OBJ)/GUIGame.o $(SRC)/GUIGame.cpp
 
-$(BIN)/GUIGame: $(OBJ)/GUIGame.o $(OBJ)/GameEngine.o
-	$(CPPC) $(FLAGS) $(SDLFLAGS) $(SDLIMGFLAGS) -o $(BIN)/GUIGame $(OBJ)/GUIGame.o $(OBJ)/GameEngine.o
+$(BIN)/GUIGame: $(OBJ)/GUIGame.o $(OBJ)/GameEngine.o $(OBJ)/BitBuffer.o
+	$(CPPC) $(FLAGS) $(SDLFLAGS) $(SDLIMGFLAGS) -o $(BIN)/GUIGame $(OBJ)/GUIGame.o $(OBJ)/GameEngine.o $(OBJ)/BitBuffer.o
+
+$(OBJ)/BitBuffer.o: $(SRC)/BitBuffer.cpp $(SRC)/BitBuffer.h
+	$(CPPC) $(FLAGS) -c -o $(OBJ)/BitBuffer.o $(SRC)/BitBuffer.cpp
 
 clean:
 	rm -f $(ALL) $(OBJ)/*.o

--- a/src/BitBuffer.cpp
+++ b/src/BitBuffer.cpp
@@ -1,0 +1,47 @@
+/* Read and write files bit-by-bit.
+ *
+ * Author: Joey Rees-Hill
+ *
+ * Date: May 2019
+ */
+
+#include <cstdio>
+#include <string>
+#include <climits>
+#include "BitBuffer.h"
+
+BitBuffer::BitBuffer(FILE* f) {
+    file = f;
+    bit_count = 0;
+    buffer = 0;
+}
+
+BitBuffer::~BitBuffer() {
+}
+
+bool BitBuffer::getBit() {
+    if (0 == bit_count) {
+        int readVal = fgetc(file);
+        buffer = readVal != EOF ? readVal : 0;
+        bit_count = CHAR_BIT;
+    }
+
+    return buffer & (0x1 << --bit_count);
+}
+
+void BitBuffer::putBit(bool bit) {
+    buffer <<= 1;
+    buffer |= bit;
+    bit_count++;
+
+    if (CHAR_BIT == bit_count) {
+        fputc(buffer, file);
+        bit_count = 0;
+    }
+}
+
+void BitBuffer::flush() {
+    while (bit_count != 0) {
+        putBit(false);
+    }
+}

--- a/src/BitBuffer.h
+++ b/src/BitBuffer.h
@@ -1,0 +1,25 @@
+/* Read/write files bit-by-bit.
+ *
+ * Author: Joey Rees-Hill
+ *
+ * Date: May 2019
+ */
+
+#ifndef BITBUFFER_H
+#define BITBUFFER_H
+
+class BitBuffer {
+    public:
+        BitBuffer(FILE*);
+        ~BitBuffer(void);
+        bool getBit(void);
+        void putBit(bool);
+        void flush(void);
+
+    private:
+        FILE *file;
+        unsigned char buffer;
+        int bit_count;
+};
+
+#endif

--- a/src/GUIGame.cpp
+++ b/src/GUIGame.cpp
@@ -427,4 +427,8 @@ int main(int argc, char *argv[]) {
 
     GameGUI game;
     game.gameLoop(inpDump, readFromFile);
+    if (inpDump != NULL) {
+        fclose(inpDump);
+        inpDump = NULL;
+    }
 }

--- a/src/GUIGame.cpp
+++ b/src/GUIGame.cpp
@@ -419,8 +419,16 @@ int main(int argc, char *argv[]) {
     if (argc > 2) {
         if (!strcmp(argv[1], "-o")) {
             inpDump = fopen(argv[2], "w");
+            if (NULL == inpDump) {
+                fprintf(stderr, "Error opening file.\n");
+                return 1;
+            }
         } else if (!strcmp(argv[1], "-i")) {
             inpDump = fopen(argv[2], "r");
+            if (NULL == inpDump) {
+                fprintf(stderr, "Error opening file.\n");
+                return 1;
+            }
             readFromFile = true;
         }
     }


### PR DESCRIPTION
Using the `-o` flag with GUIGame allows you to write your button inputs to a file.

Using the `-i` flag allows you to read input from the file instead of the keyboard.

This allows you to recreate a game:

1. Play game and dump input:
    `bin/GUIGame -o inps.txt`
2. Re-run game with dumped input:
    `bin/GUIGame -i inps.txt`

I believe @wknowleskellett asked for this…